### PR TITLE
Update check to add warning to perf

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -143,10 +143,10 @@ class Epitelete {
     async checkPerfSequence(perfSequence) {
         let currentChapter = 0;
         let currentVerse = 0;
-        const warnings = [];
         for (const block of perfSequence.blocks) {
             if( Array.isArray(block.content) ) {
                 for (const contentBlock of block.content) {
+                    const warnings = contentBlock.warnings || [];
                     if ('verses' === contentBlock.type) {
                         currentVerse++;
                         if (currentVerse.toString() !== contentBlock.number) {
@@ -162,10 +162,13 @@ class Epitelete {
                         }
                         currentVerse = 0;
                     }
+                    if ( warnings.length > 0 ) {
+                        contentBlock.warnings = warnings;
+                    }
                 }
             }
         }
-        return warnings;
+        return perfSequence;
     }
 
     localBookCodes() {


### PR DESCRIPTION
Related https://github.com/Proskomma/epitelete/issues/17
This is a demonstration of updating the PERF itself with the content warnings rather that passing all the warnings as separate data. I find doing it this way would be simpler but I could see advantages to both ways.