### PR TITLE
makeDocumentReport demonstrated with wordSearch pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "bash -c \"babel-tape-runner test/code/*.cjs | node_modules/tap-summary/bin/cmd.js\"",
     "rawTest": "babel-tape-runner test/code/*.cjs",
     "oneTest": "babel-tape-runner test/code/%TESTSCRIPT%.cjs",
+    "oneTestOnLinux": "babel-tape-runner test/code/$TESTSCRIPT.cjs",
     "build": "babel src -d dist",
     "prepublishOnly": "rm -fr dist && npm run build",
     "generatePerf": "babel-tape-runner utils/generatePerf.js",
@@ -30,7 +31,7 @@
   "dependencies": {
     "@babel/core": "^7.17.10",
     "lodash": "4.17.21",
-    "proskomma-json-tools": "^0.4.1"
+    "proskomma-json-tools": "^0.4.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.10",

--- a/src/evaluateSteps.js
+++ b/src/evaluateSteps.js
@@ -2,7 +2,7 @@ import transforms from './transforms';
 
 const verbose = false;
 
-const evaluateSteps = ({specSteps, inputValues}) => {
+const evaluateSteps = async ({specSteps, inputValues}) => {
     verbose && console.log("** Evaluate **");
     // Find input, output and transforms
     const inputStep = specSteps.filter(s => s.type==="Inputs")[0];

--- a/src/evaluateSteps.js
+++ b/src/evaluateSteps.js
@@ -1,0 +1,88 @@
+import transforms from './transforms';
+
+const verbose = false;
+
+const evaluateSteps = ({specSteps, inputValues}) => {
+    verbose && console.log("** Evaluate **");
+    // Find input, output and transforms
+    const inputStep = specSteps.filter(s => s.type==="Inputs")[0];
+    if (!inputStep) {
+        throw new Error(`No Inputs step found in report steps`);
+    }
+    const outputStep = specSteps.filter(s => s.type==="Outputs")[0];
+    if (!outputStep) {
+        throw new Error(`No Outputs step found in report steps`);
+    }
+    const transformSteps = specSteps.filter(s => s.type==="Transform");
+    if (transformSteps.length === 0) {
+        throw new Error(`No Transform steps found in report steps`);
+    }
+    const transformInputs = {};
+    const transformOutputs = {};
+    for (const transformStep of Object.values(transformSteps)) {
+        transformInputs[transformStep.id] = {};
+        for (const input of transformStep.inputs) {
+            transformInputs[transformStep.id][input.name] = null;
+        }
+        transformOutputs[transformStep.id] = {};
+        for (const output of transformStep.outputs) {
+            transformOutputs[transformStep.id][output] = null;
+        }
+    }
+    // Copy inputs to transforms
+    for (const [inputKey, inputValue] of Object.entries(inputValues)) {
+        for (const transformStep of transformSteps) {
+            for (const input of transformStep.inputs) {
+                if (input.source === `Input ${inputKey}`) {
+                    verbose && console.log(`Copying Input ${inputKey} to Transform ${transformStep.id} ${input.name} input`);
+                    transformInputs[transformStep.id][input.name] = inputValue;
+                }
+            }
+        }
+    }
+    // Propagate values between transforms until nothing changes
+    let changed = true;
+    let nWaitingTransforms = 0;
+    while (changed) {
+        changed = false;
+        for (const transformStep of transformSteps) {
+            if (
+                Object.values(transformInputs[transformStep.id]).filter(i => !i).length === 0 &&
+                Object.values(transformOutputs[transformStep.id]).filter(i => !i).length > 0
+            ) {
+                verbose && console.log(`Evaluating Transform ${transformStep.id}`);
+                try {
+                    transformOutputs[transformStep.id] = transforms[transformStep.transformName].code({...transformInputs[transformStep.id]});
+                } catch (err) {
+                    const errMsg = `Error evaluating Transform ${transformStep.id} (name=${transformStep.name}, type=${typeof transformStep.code}): ${err}`;
+                    throw new Error(errMsg);
+                }
+                for (const consumingTransform of transformSteps) {
+                    for (const consumingInput of consumingTransform.inputs) {
+                        for (const resolvedOutput of Object.keys(transformOutputs[transformStep.id])) {
+                            if (consumingInput.source === `Transform ${transformStep.id} ${resolvedOutput}`) {
+                                verbose && console.log(`Copying Transform ${transformStep.id} ${resolvedOutput} output to Transform ${consumingTransform.id} ${consumingInput.name} input`);
+                                transformInputs[consumingTransform.id][consumingInput.name] = transformOutputs[transformStep.id][resolvedOutput];
+                            }
+                        }
+                    }
+                }
+                changed = true;
+            }
+        }
+    }
+    if (nWaitingTransforms) {
+        throw new Error(`Inputs not satisfied for ${nWaitingTransforms} transform(s)`);
+    }
+    // Copy to output;
+    const outputValues = {};
+    for (const output of outputStep.outputs) {
+        const transformN = output.source.split(' ')[1];
+        verbose && console.log(`Copying Transform ${transformN} ${output.name} to Output ${output.name}`);
+        outputValues[output.name] = transformOutputs[transformN][output.name];
+    }
+    verbose && console.log("****");
+    return outputValues;
+}
+
+export default evaluateSteps;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {Validator, ProskommaRenderFromJson, toUsfmActions} from 'proskomma-json-tools';
 import reports from './pipelines/reports';
+import evaluateSteps from "./evaluateSteps";
 const _ = require("lodash");
 
 /**
@@ -355,14 +356,14 @@ class Epitelete {
         if (!this.localBookCodes().includes(bookCode)) {
             throw new Error(`bookCode '${bookCode}' is not available locally`);
         }
+        data.perf = this.getDocument(bookCode);
         if (!reports[reportName]) {
             throw new Error(`Unknown report name '${reportName}'`);
         }
         const pipeline = reports[reportName];
         const inputSpecs = pipeline[0].inputs;
-        const outputSpec = pipeline[pipeline.length - 1].outputs;
         if (Object.keys(inputSpecs).length !== Object.keys(data).length) {
-            throw new Error(`${inputSpecs.length} input(s) expected by report ${reportName} but ${Object.keys(data).length} provided`);
+            throw new Error(`${Object.keys(inputSpecs).length} input(s) expected by report ${reportName} but ${Object.keys(data).length} provided (${Object.keys(data).join(', ')})`);
         }
         for (const [inputSpecName, inputSpecType] of Object.entries(inputSpecs)) {
             if (!data[inputSpecName]) {
@@ -372,7 +373,7 @@ class Epitelete {
                 throw new Error(`Input ${inputSpecName} must be ${inputSpecType} but ${typeof data[inputSpecName] === 'string' ? "text": "json"} was provided`);
             }
         }
-        return [];
+        return evaluateSteps({specSteps: reports[reportName], inputValues: data});
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -352,7 +352,7 @@ class Epitelete {
      * @param {object} data
      * @return {array} A report
      */
-    makeDocumentReport(bookCode, reportName, data) {
+    async makeDocumentReport(bookCode, reportName, data) {
         if (!this.localBookCodes().includes(bookCode)) {
             throw new Error(`bookCode '${bookCode}' is not available locally`);
         }
@@ -373,7 +373,7 @@ class Epitelete {
                 throw new Error(`Input ${inputSpecName} must be ${inputSpecType} but ${typeof data[inputSpecName] === 'string' ? "text": "json"} was provided`);
             }
         }
-        return evaluateSteps({specSteps: reports[reportName], inputValues: data});
+        return await evaluateSteps({specSteps: reports[reportName], inputValues: data});
     }
 
     /**
@@ -382,11 +382,11 @@ class Epitelete {
      * @param {object} data
      * @return {object} reports for each documents with bookCode as the key
      */
-    makeDocumentsReport(reportName, data) {
+    async makeDocumentsReport(reportName, data) {
         const bookCodes = this.localBookCodes();
-        const bookReports = bookCodes.map(bc => this.makeDocumentReport(bc, reportName, data));
         const ret = {};
-        for (const bookReport of bookReports) {
+        for (const bookCode of bookCodes) {
+            const bookReport = await this.makeDocumentReport(bookCode, reportName, data);
             ret[bookReport.matches.bookCode] = bookReport;
         }
         return ret;

--- a/src/index.js
+++ b/src/index.js
@@ -383,7 +383,13 @@ class Epitelete {
      * @return {object} reports for each documents with bookCode as the key
      */
     makeDocumentsReport(reportName, data) {
-        return {};
+        const bookCodes = this.localBookCodes();
+        const bookReports = bookCodes.map(bc => this.makeDocumentReport(bc, reportName, data));
+        const ret = {};
+        for (const bookReport of bookReports) {
+            ret[bookReport.matches.bookCode] = bookReport;
+        }
+        return ret;
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import {Validator, ProskommaRenderFromJson, toUsfmActions} from 'proskomma-json-tools';
+import reports from './pipelines/reports';
 const _ = require("lodash");
 
 /**
@@ -35,7 +36,7 @@ class Epitelete {
 
         const { hs, ...opt } = options;
         const historySize = hs ? hs + 1 : 11//add one to passed history size so it matches undos allowed.
-        
+
         this.options = {
             historySize,
             ...opt
@@ -341,6 +342,33 @@ class Epitelete {
         const output = {};
         renderer.renderDocument({docId: "", config: {}, output});
         return output.usfm;
+    }
+
+    /**
+     * Generates and returns a report via a transform pipeline
+     * @param {string} bookCode
+     * @param {string} reportName
+     * @param {object} data
+     * @return {array} A report
+     */
+    makeDocumentReport(bookCode, reportName, data) {
+        if (!this.localBookCodes().includes(bookCode)) {
+            throw new Error(`bookCode '${bookCode}' is not available locally`);
+        }
+        if (!reports[reportName]) {
+            throw new Error(`Unknown report name '${reportName}'`);
+        }
+        return [];
+    }
+
+    /**
+     * Generates and returns a report for each document via a transform pipeline
+     * @param {string} reportName
+     * @param {object} data
+     * @return {object} reports for each documents with bookCode as the key
+     */
+    makeDocumentsReport(reportName, data) {
+        return {};
     }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -358,6 +358,20 @@ class Epitelete {
         if (!reports[reportName]) {
             throw new Error(`Unknown report name '${reportName}'`);
         }
+        const pipeline = reports[reportName];
+        const inputSpecs = pipeline[0].inputs;
+        const outputSpec = pipeline[pipeline.length - 1].outputs;
+        if (Object.keys(inputSpecs).length !== Object.keys(data).length) {
+            throw new Error(`${inputSpecs.length} input(s) expected by report ${reportName} but ${Object.keys(data).length} provided`);
+        }
+        for (const [inputSpecName, inputSpecType] of Object.entries(inputSpecs)) {
+            if (!data[inputSpecName]) {
+                throw new Error(`Input ${inputSpecName} not provided as input to ${reportName}`);
+            }
+            if ((typeof data[inputSpecName] === 'string') !== (inputSpecType === 'text')) {
+                throw new Error(`Input ${inputSpecName} must be ${inputSpecType} but ${typeof data[inputSpecName] === 'string' ? "text": "json"} was provided`);
+            }
+        }
         return [];
     }
 

--- a/src/pipelines/reports/index.js
+++ b/src/pipelines/reports/index.js
@@ -1,0 +1,5 @@
+import wordSearch from "./wordSearch";
+
+export default {
+    wordSearch
+};

--- a/src/pipelines/reports/wordSearch.json
+++ b/src/pipelines/reports/wordSearch.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 0,
-    "type": "inputs",
+    "type": "Inputs",
     "inputs": {
       "perf": "json",
       "searchString": "text"
@@ -12,6 +12,7 @@
     "title": "Word Search",
     "name": "wordSearch",
     "type": "Transform",
+    "transformName": "wordSearch",
     "inputs": [
       {
         "name": "perf",
@@ -34,7 +35,7 @@
   },
   {
     "id": 999,
-    "type": "outputs",
+    "type": "Outputs",
     "outputs": [
       {
         "name": "matches",

--- a/src/pipelines/reports/wordSearch.json
+++ b/src/pipelines/reports/wordSearch.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id":  0,
+    "type": "inputs",
+    "inputs": [
+      {
+        "name": "perf",
+        "type": "json"
+      },
+      {
+        "name": "searchString",
+        "type": "text"
+      }
+    ]
+  },
+  {
+    "id": 6,
+    "title": "Word Search",
+    "name": "wordSearch",
+    "type": "Transform",
+    "inputs": [
+      {
+        "name": "perf",
+        "type": "json",
+        "source": "Input perf"
+      },
+      {
+        "name": "searchString",
+        "type": "text",
+        "source": "Input searchString"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "matches",
+        "type": "json"
+      }
+    ],
+    "description": "PERF=>JSON: Searches for a word"
+  },
+  {
+    "id": 999,
+    "type": "outputs",
+    "outputs": [
+      {
+        "name": "matches",
+        "source": "Transform 6 matches"
+      }
+    ]
+  }
+]

--- a/src/pipelines/reports/wordSearch.json
+++ b/src/pipelines/reports/wordSearch.json
@@ -4,25 +4,129 @@
     "type": "Inputs",
     "inputs": {
       "perf": "json",
-      "searchString": "text"
+      "searchString": "text",
+      "ignoreCase": "text",
+      "asRegex": "text",
+      "logic": "text",
+      "asPartial": "text"
     }
   },
   {
-    "id": 6,
-    "title": "Word Search",
-    "name": "wordSearch",
+    "id": 8,
+    "title": "Simplify Input PERF",
+    "name": "justTheBible",
+    "transformName": "justTheBible",
     "type": "Transform",
-    "transformName": "wordSearch",
     "inputs": [
       {
         "name": "perf",
         "type": "json",
         "source": "Input perf"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "perf",
+        "type": "json"
+      }
+    ]
+  },
+  {
+    "id": 9,
+    "title": "Merge Text in Input PERF",
+    "name": "mergePerfText",
+    "transformName": "mergePerfText",
+    "type": "Transform",
+    "inputs": [
+      {
+        "name": "perf",
+        "type": "json",
+        "source": "Transform 8 perf"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "perf",
+        "type": "json"
+      }
+    ]
+  },
+  {
+    "id": 5,
+    "title": "Search Term",
+    "type": "Source",
+    "sourceLocation": "local",
+    "localValue": "Jesus",
+    "outputType": "text"
+  },
+  {
+    "id": 11,
+    "title": "Ignore Case",
+    "type": "Source",
+    "sourceLocation": "local",
+    "localValue": "1",
+    "outputType": "text"
+  },
+  {
+    "id": 12,
+    "title": "Regex",
+    "type": "Source",
+    "sourceLocation": "local",
+    "localValue": "0",
+    "outputType": "text"
+  },
+  {
+    "id": 15,
+    "title": "Logic",
+    "type": "Source",
+    "sourceLocation": "local",
+    "localValue": "O",
+    "outputType": "text"
+  },
+  {
+    "id": 16,
+    "title": "Partial",
+    "type": "Source",
+    "sourceLocation": "local",
+    "localValue": "0",
+    "outputType": "text"
+  },
+  {
+    "id": 10,
+    "title": "Do Word Search",
+    "name": "wordSearch",
+    "transformName": "wordSearch",
+    "type": "Transform",
+    "inputs": [
+      {
+        "name": "perf",
+        "type": "json",
+        "source": "Transform 9 perf"
       },
       {
         "name": "searchString",
         "type": "text",
         "source": "Input searchString"
+      },
+      {
+        "name": "ignoreCase",
+        "type": "text",
+        "source": "Input ignoreCase"
+      },
+      {
+        "name": "regex",
+        "type": "text",
+        "source": "Input asRegex"
+      },
+      {
+        "name": "logic",
+        "type": "text",
+        "source": "Input logic"
+      },
+      {
+        "name": "partial",
+        "type": "text",
+        "source": "Input asPartial"
       }
     ],
     "outputs": [
@@ -30,8 +134,7 @@
         "name": "matches",
         "type": "json"
       }
-    ],
-    "description": "PERF=>JSON: Searches for a word"
+    ]
   },
   {
     "id": 999,
@@ -40,7 +143,7 @@
       {
         "name": "matches",
         "type": "json",
-        "source": "Transform 6 matches"
+        "source": "Transform 10 matches"
       }
     ]
   }

--- a/src/pipelines/reports/wordSearch.json
+++ b/src/pipelines/reports/wordSearch.json
@@ -1,17 +1,11 @@
 [
   {
-    "id":  0,
+    "id": 0,
     "type": "inputs",
-    "inputs": [
-      {
-        "name": "perf",
-        "type": "json"
-      },
-      {
-        "name": "searchString",
-        "type": "text"
-      }
-    ]
+    "inputs": {
+      "perf": "json",
+      "searchString": "text"
+    }
   },
   {
     "id": 6,
@@ -44,6 +38,7 @@
     "outputs": [
       {
         "name": "matches",
+        "type": "json",
         "source": "Transform 6 matches"
       }
     ]

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -1,0 +1,5 @@
+import wordSearch from "./wordSearch";
+
+export {
+    wordSearch
+}

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -1,5 +1,9 @@
 import wordSearch from "./wordSearch";
+import justTheBible from "./justTheBible";
+import mergePerfText from "./mergePerfText";
 
 export default {
-    wordSearch
+    wordSearch,
+    justTheBible,
+    mergePerfText
 }

--- a/src/transforms/index.js
+++ b/src/transforms/index.js
@@ -1,5 +1,5 @@
 import wordSearch from "./wordSearch";
 
-export {
+export default {
     wordSearch
 }

--- a/src/transforms/justTheBible.js
+++ b/src/transforms/justTheBible.js
@@ -1,0 +1,99 @@
+import {ProskommaRenderFromJson, transforms, mergeActions} from 'proskomma-json-tools';
+
+const localJustTheBibleActions = {
+    startMilestone: [
+        {
+            description: "Ignore startMilestone events",
+            test: () => true,
+            action: () => {
+            }
+        },
+    ],
+    endMilestone: [
+        {
+            description: "Ignore endMilestone events",
+            test: () => true,
+            action: () => {
+            }
+        },
+    ],
+    startWrapper: [
+        {
+            description: "Ignore startWrapper events",
+            test: () => true,
+            action: () => {
+            }
+        },
+    ],
+    endWrapper: [
+        {
+            description: "Ignore endWrapper events",
+            test: () => true,
+            action: () => {
+            }
+        },
+    ],
+    blockGraft: [
+        {
+            description: "Ignore blockGraft events, except for title (\\mt)",
+            test: (environment) => environment.context.sequences[0].block.subType !== 'title',
+            action: (environment) => {
+            }
+        },
+    ],
+    inlineGraft: [
+        {
+            description: "Ignore inlineGraft events",
+            test: () => true,
+            action: () => {
+            }
+        },
+    ],
+    mark: [
+        {
+            description: "Ignore mark events, except for chapter and verses",
+            test: ({context}) => !['chapter', 'verses'].includes(context.sequences[0].element.subType),
+            action: () => {
+            }
+        },
+    ],
+};
+
+const justTheBibleCode = function ({perf}) {
+    const cl = new ProskommaRenderFromJson(
+        {
+            srcJson: perf,
+            actions: mergeActions(
+                [
+                    localJustTheBibleActions,
+                    transforms.identityActions
+                ]
+            )
+        }
+    );
+    const output = {};
+    cl.renderDocument({docId: "", config: {}, output});
+    return {perf: output.perf}; // identityActions currently put PERF directly in output
+}
+
+const justTheBible = {
+    name: "justTheBible",
+    type: "Transform",
+    description: "PERF=>PERF: Strips most markup",
+    documentation: "This transform removes milestones, wrappers and most marks. It has been used in several pipelines. It may also be stripping metaContent.",
+    inputs: [
+        {
+            name: "perf",
+            type: "json",
+            source: ""
+        },
+    ],
+    outputs: [
+        {
+            name: "perf",
+            type: "json",
+        }
+    ],
+    code: justTheBibleCode
+}
+export default justTheBible;

--- a/src/transforms/mergePerfText.js
+++ b/src/transforms/mergePerfText.js
@@ -1,0 +1,65 @@
+import deepCopy from 'deep-copy-all';
+
+const doMerge1 = content => {
+    let ret = [];
+    for (const element of content) {
+        if (typeof element === 'string') {
+            if (ret.length > 0 && typeof ret[ret.length - 1] === 'string') {
+                ret[ret.length - 1] += element;
+            } else {
+                ret.push(element);
+            }
+        } else {
+            if (element.content) {
+                element.content = doMerge1(element.content);
+            }
+            if (element.metaContent) {
+                element.metaContent = doMerge1(element.content);
+            }
+            ret.push(element);
+        }
+    }
+    return ret;
+}
+
+const doMerge = perf => {
+    const newPerf = deepCopy(perf);
+    for (const seq of Object.values(newPerf.sequences)) {
+        for (const block of seq.blocks) {
+            if (block.content) {
+                block.content = doMerge1(block.content);
+            }
+            if (block.metaContent) {
+                block.metaContent = doMerge1(block.metaContent);
+            }
+        }
+    }
+    return newPerf;
+}
+
+
+const mergePerfTextCode = function ({perf}) {
+    return {perf: doMerge(perf)};
+}
+
+const mergePerfText = {
+    name: "mergePerfText",
+    type: "Transform",
+    description: "PERF=>PERF: Merge consecutive text strings",
+    inputs: [
+        {
+            name: "perf",
+            type: "json",
+            source: ""
+        },
+     ],
+    outputs: [
+        {
+            name: "perf",
+            type: "json",
+        }
+    ],
+    code: mergePerfTextCode
+}
+
+export default mergePerfText;

--- a/src/transforms/wordSearch.js
+++ b/src/transforms/wordSearch.js
@@ -1,4 +1,6 @@
 import {ProskommaRenderFromJson} from 'proskomma-json-tools';
+import xre from "xregexp";
+const splitWords = xre('([\\p{Letter}\\p{Number}\\p{Mark}\\u2060]{1,127})');
 
 const localWordSearchActions = {
     startDocument: [
@@ -9,6 +11,10 @@ const localWordSearchActions = {
                 workspace.chapter = null;
                 workspace.verses = null;
                 workspace.matches = new Set([]);
+                workspace.chunks = [];
+                if (config.regex) {
+                    workspace.regex = new RegExp(config.toSearch, config.regexFlags);
+                }
             }
         },
     ],
@@ -19,9 +25,13 @@ const localWordSearchActions = {
             action: ({config, context, workspace, output}) => {
                 const element = context.sequences[0].element;
                 if (element.subType === 'chapter') {
+                    doSearch(workspace, config);
                     workspace.chapter = element.atts['number'];
+                    workspace.chunks = [];
                 } else if (element.subType === 'verses') {
+                    doSearch(workspace, config);
                     workspace.verses = element.atts['number'];
+                    workspace.chunks = [];
                 }
             }
         },
@@ -32,9 +42,7 @@ const localWordSearchActions = {
             test: ({context, workspace}) => workspace.chapter && workspace.verses,
             action: ({config, context, workspace, output}) => {
                 const text = context.sequences[0].element.text;
-                if (text.toLowerCase().includes(config.toSearch.toLowerCase())) {
-                    workspace.matches.add(`${workspace.chapter}:${workspace.verses}`);
-                }
+                workspace.chunks.push(text);
             }
         },
     ],
@@ -43,20 +51,165 @@ const localWordSearchActions = {
             description: "Sort matches",
             test: () => true,
             action: ({config, context, workspace, output}) => {
+                output.bookCode = context?.document?.metadata?.document?.bookCode || '';
+                output.searchTerms = Array.isArray(config.toSearch) ? config.toSearch.join(' ') : config.toSearch;
+                output.options = [];
+                if (config.ignoreCase) {
+                  output.options.push('ignoreCase');
+                }
+                if (config.andLogic) {
+                  output.options.push('andLogic');
+                }
+                if (config.orLogic) {
+                  output.options.push('orLogic');
+                }
+                if (config.partialMatch) {
+                    output.options.push('partialMatch');
+                }
+                if (config.regex) {
+                    output.options.push('regex');
+                }
+                doSearch(workspace, config);
                 output.matches = Array.from(workspace.matches)
-                    .map(cv => cv.split(':').map(b => parseInt(b)))
-                    .sort((a, b) => ((a[0] * 1000) + a[1]) - ((b[0] * 1000) + b[1]))
-                    .map(cva => cva.join(':'))
+                    .sort((a, b) => ((a.chapter * 1000) + a.verses) - ((b.chapter * 1000) + b.verses))
             }
         },
     ],
 };
 
-const wordSearchCode = function ({perf, searchString}) {
+const addMatch = function(workspace, config) {
+    const match = {
+        chapter: workspace.chapter,
+        verses: workspace.verses,
+        content: []
+    };
+
+    let search = config.toSearch;
+    const config_ = {
+      ...config,
+      andLogic: false, // for highlighting we match any found
+    }
+    
+    let text = workspace.chunks.join('');
+    const words = xre.split(text, splitWords);
+    
+    for (const value of words) {
+      if (value) {
+        const found = findMatch(config_, value, search, workspace);
+        if (found) {
+          match.content.push({
+            type: "wrapper",
+            subtype: "x-search-match",
+            content: [
+              value
+            ]
+          });
+        } else {
+          match.content.push(value);
+        }
+      }
+    }
+    workspace.matches.add( match );
+}
+
+function findMatch(config, text, search, workspace) {
+    if (config.regex) {
+        return workspace.regex.test(text);
+    } 
+    
+    const isSearchArray = Array.isArray(search);
+    if (config.ignoreCase) {
+    text = text.toLowerCase();
+    if (isSearchArray) {
+      search = search.map(item => item.toLowerCase());
+    } else {
+      search = search.toLowerCase();
+    }
+  }
+
+  if (!isSearchArray) {
+    search = [search];
+  }
+  
+  if (!config.partialMatch) { // if word search, we separate text into array of words to match
+    const words = xre.split(text, splitWords);
+    text = words;
+  }
+  
+  let allMatched = true;
+  let anyMatched = false;
+  for (const searchTerm of search) {
+    const found = text.includes(searchTerm);
+    if (!found) {
+      allMatched = false;
+    } else {
+      anyMatched = true;
+    }
+  }
+  if (config.andLogic) {
+    return allMatched;
+  } else { // doing or logic
+    return anyMatched;
+  }
+}
+
+const doSearch = function(workspace, config){
+    if (workspace.chunks.length) {
+        let text = workspace.chunks.join(''); 
+        
+        let search_ = config.toSearch;
+        const found = findMatch(config, text, search_, workspace);
+        if (found) {
+            addMatch(workspace, config);
+        }
+    }
+}
+
+const wordSearchCode = function ({perf, searchString, ignoreCase = '1', logic = '', regex = '0', partialMatch = '0'}) {
     const cl = new ProskommaRenderFromJson({srcJson: perf, actions: localWordSearchActions});
     const output = {};
-    cl.renderDocument({docId: "", config: {toSearch: searchString.trim()}, output});
-        return {matches: output.matches};
+    const ignoreCase_ = ignoreCase.trim() === '1';
+    logic = logic.trim().substring(0,1).toUpperCase();
+    const andLogic_ = logic === 'A';
+    const orLogic_ = logic === 'O';
+    const partialMatch_ = partialMatch && partialMatch.trim() === '1';
+    let regex_ = regex.trim() === '1';
+    let toSearch = searchString.trim();
+    if (!regex_) {
+      if (toSearch.includes('?') || toSearch.includes('*')) { // check for wildcard characters
+        let newSearch = toSearch.replaceAll('?', '\\S{1}');
+        newSearch = newSearch.replaceAll('*', '\\S*');
+        toSearch = '/' + newSearch + '/';
+      }
+    }
+    
+    let regexFlags = '';
+    if ( toSearch.startsWith('/') && toSearch.includes('/', 2) ) {
+        regex_ = true;
+        const regexParts = toSearch.split('/');
+        toSearch = regexParts[1];
+        regexFlags = regexParts[2];
+
+        if (ignoreCase_ && ! regexFlags.includes('i')) {
+          regexFlags += 'i';
+        }
+    } else if ((andLogic_ || orLogic_) && toSearch) {
+      toSearch = toSearch.split(' ');
+    }
+
+    cl.renderDocument({
+        docId: "",
+        config: {
+            toSearch,
+            ignoreCase: ignoreCase_,
+            andLogic: andLogic_,
+            orLogic: orLogic_,
+            partialMatch: partialMatch_,
+            regex: regex_,
+            regexFlags
+        },
+        output});
+    return {matches: output};
 }
 
 const wordSearch = {
@@ -71,6 +224,26 @@ const wordSearch = {
         },
         {
             name: "searchString",
+            type: "text",
+            source: ""
+        },
+        {
+            name: "ignoreCase", // expect '1' to enable case insensitive, otherwise we do case sensitive searching
+            type: "text",
+            source: ""
+        },
+        {
+            name: "regex", // expect '1' to enable
+            type: "text",
+            source: ""
+        },
+        {
+            name: "logic", // expect 'A' to enable AND logic, 'O' to enable OR logic, default is exact match search string
+            type: "text",
+            source: ""
+        },
+        {
+            name: "partial", // expect '1' to enable partial match of words/string, otherwise we do full word matching
             type: "text",
             source: ""
         },

--- a/src/transforms/wordSearch.js
+++ b/src/transforms/wordSearch.js
@@ -1,0 +1,86 @@
+import {ProskommaRenderFromJson} from 'proskomma-json-tools';
+
+const localWordSearchActions = {
+    startDocument: [
+        {
+            description: "Set up state variables and output",
+            test: () => true,
+            action: ({config, context, workspace, output}) => {
+                workspace.chapter = null;
+                workspace.verses = null;
+                workspace.matches = new Set([]);
+            }
+        },
+    ],
+    mark: [
+        {
+            description: "Update CV state",
+            test: () => true,
+            action: ({config, context, workspace, output}) => {
+                const element = context.sequences[0].element;
+                if (element.subType === 'chapter') {
+                    workspace.chapter = element.atts['number'];
+                } else if (element.subType === 'verses') {
+                    workspace.verses = element.atts['number'];
+                }
+            }
+        },
+    ],
+    text: [
+        {
+            description: "Add matching verses to set",
+            test: ({context, workspace}) => workspace.chapter && workspace.verses,
+            action: ({config, context, workspace, output}) => {
+                const text = context.sequences[0].element.text;
+                if (text.toLowerCase().includes(config.toSearch.toLowerCase())) {
+                    workspace.matches.add(`${workspace.chapter}:${workspace.verses}`);
+                }
+            }
+        },
+    ],
+    endDocument: [
+        {
+            description: "Sort matches",
+            test: () => true,
+            action: ({config, context, workspace, output}) => {
+                output.matches = Array.from(workspace.matches)
+                    .map(cv => cv.split(':').map(b => parseInt(b)))
+                    .sort((a, b) => ((a[0] * 1000) + a[1]) - ((b[0] * 1000) + b[1]))
+                    .map(cva => cva.join(':'))
+            }
+        },
+    ],
+};
+
+const wordSearchCode = function ({perf, searchString}) {
+    const cl = new ProskommaRenderFromJson({srcJson: perf, actions: localWordSearchActions});
+    const output = {};
+    cl.renderDocument({docId: "", config: {toSearch: searchString.trim()}, output});
+        return {matches: output.matches};
+}
+
+const wordSearch = {
+    name: "wordSearch",
+    type: "Transform",
+    description: "PERF=>JSON: Searches for a word",
+    inputs: [
+        {
+            name: "perf",
+            type: "json",
+            source: ""
+        },
+        {
+            name: "searchString",
+            type: "text",
+            source: ""
+        },
+    ],
+    outputs: [
+        {
+            name: "matches",
+            type: "json",
+        }
+    ],
+    code: wordSearchCode
+}
+export default wordSearch;

--- a/test/code/makeDocumentReport.cjs
+++ b/test/code/makeDocumentReport.cjs
@@ -28,17 +28,23 @@ test(
         const docSetId = "DBL/eng_engWEBBE";
         const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        t.throws(
-            () => epitelete.makeDocumentReport(
+        try {
+            await epitelete.makeDocumentReport(
                 "banana",
                 "wordSearch",
                 {
                     perf: {},
                     searchString: "foo"
                 }
-            ),
-            /banana/
-        );
+            );
+            t.fail("Should have thrown");
+        } catch (err) {
+            if (err.toString().includes('banana')) {
+                t.ok(err, "Expected error");
+            } else {
+                t.fail(`Unexpected error ${err}`)
+            }
+        }
     }
 )
 
@@ -49,19 +55,26 @@ test(
         const docSetId = "DBL/eng_engWEBBE";
         const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        t.throws(
-            () => epitelete.makeDocumentReport(
+        try {
+            await epitelete.makeDocumentReport(
                 "LUK",
                 "banana",
                 {
                     perf: {},
                     searchString: "foo"
                 }
-            ),
-            /banana/
-        );
+            );
+            t.fail("Should have thrown");
+        } catch (err) {
+            if (err.toString().includes('banana')) {
+                t.ok(err, "Expected error");
+            } else {
+                t.fail(`Unexpected error ${err}`)
+            }
+        }
     }
 )
+
 
 test(
     `makeDocumentReport() throws when inputs do not match spec (${testGroup})`,
@@ -70,8 +83,8 @@ test(
         const docSetId = "DBL/eng_engWEBBE";
         const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        t.throws(
-            () => epitelete.makeDocumentReport(
+        try {
+            await epitelete.makeDocumentReport(
                 "LUK",
                 "wordSearch",
                 {
@@ -79,11 +92,17 @@ test(
                     perf: {},
                     searchString: "foo"
                 }
-            ),
-            /3 provided/
-        );
-        t.throws(
-            () => epitelete.makeDocumentReport(
+            );
+            t.fail("Should have thrown");
+        } catch (err) {
+            if (err.toString().includes('3 provided')) {
+                t.ok(err, "Expected error");
+            } else {
+                t.fail(`Unexpected error ${err}`)
+            }
+        }
+        try {
+            await epitelete.makeDocumentReport(
                 "LUK",
                 "wordSearch",
                 {
@@ -94,11 +113,17 @@ test(
                     "logic": "text",
                     "asPartial": "text"
                 }
-            ),
-            /searchString not provided/
-        );
-        t.throws(
-            () => epitelete.makeDocumentReport(
+            );
+            t.fail("Should have thrown");
+        } catch (err) {
+            if (err.toString().includes('searchString not provided')) {
+                t.ok(err, "Expected error");
+            } else {
+                t.fail(`Unexpected error ${err}`)
+            }
+        }
+        try {
+            await epitelete.makeDocumentReport(
                 "LUK",
                 "wordSearch",
                 {
@@ -109,9 +134,15 @@ test(
                     "logic": "text",
                     "asPartial": "text"
                 }
-            ),
-            /searchString must be text/
-        );
+            );
+            t.fail("Should have thrown");
+        } catch (err) {
+            if (err.toString().includes('searchString must be text')) {
+                t.ok(err, "Expected error");
+            } else {
+                t.fail(`Unexpected error ${err}`)
+            }
+        }
     }
 )
 
@@ -123,7 +154,7 @@ test(
         const docSetId = "DBL/eng_engWEBBE";
         const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        const output = epitelete.makeDocumentReport(
+        const output = await epitelete.makeDocumentReport(
             "LUK",
             "wordSearch",
             {
@@ -134,12 +165,13 @@ test(
                 "logic": "A",
                 "asPartial": "0"
             }
-        );
+        ).then(output => {
+            t.ok('matches' in output);
+            t.ok('searchTerms' in output.matches);
+            t.equal(output.matches.matches[0].chapter, '1');
+            t.equal(output.matches.matches[0].verses, '5');
+        });
         // console.log(output.matches.matches);
-        t.ok('matches' in output);
-        t.ok('searchTerms' in output.matches);
-        t.equal(output.matches.matches[0].chapter, '1');
-        t.equal(output.matches.matches[0].verses, '5');
     }
 );
 
@@ -153,7 +185,7 @@ test(
         await epitelete.fetchPerf("MRK");
         await epitelete.fetchPerf("LUK");
         await epitelete.fetchPerf("JHN");
-        const output = epitelete.makeDocumentsReport(
+        const output = await epitelete.makeDocumentsReport(
             "wordSearch",
             {
                 perf: {},
@@ -163,12 +195,13 @@ test(
                 "logic": "A",
                 "asPartial": "0"
             }
-        );
+        ).then(output => {
+            t.ok('LUK' in output);
+            t.ok('matches' in output.LUK);
+            t.ok('searchTerms' in output.LUK.matches);
+            t.equal(output.LUK.matches.matches[0].chapter, '1');
+            t.equal(output.LUK.matches.matches[0].verses, '5');
+        });
         // console.log(output.matches.matches);
-        t.ok('LUK' in output);
-        t.ok('matches' in output.LUK);
-        t.ok('searchTerms' in output.LUK.matches);
-        t.equal(output.LUK.matches.matches[0].chapter, '1');
-        t.equal(output.LUK.matches.matches[0].verses, '5');
     }
 )

--- a/test/code/makeDocumentReport.cjs
+++ b/test/code/makeDocumentReport.cjs
@@ -16,7 +16,7 @@ test(
     async t => {
         t.plan(1);
         const docSetId = "DBL/eng_engWEBBE";
-        const epitelete = new Epitelete({ proskomma, docSetId });
+        const epitelete = new Epitelete({proskomma, docSetId});
         t.ok(typeof epitelete.makeDocumentReport === "function");
     }
 )
@@ -26,9 +26,19 @@ test(
     async t => {
         t.plan(1);
         const docSetId = "DBL/eng_engWEBBE";
-        const epitelete = new Epitelete({ proskomma, docSetId });
+        const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        t.throws(() => epitelete.makeDocumentReport("banana", "wordSearch", {}), /banana/);
+        t.throws(
+            () => epitelete.makeDocumentReport(
+                "banana",
+                "wordSearch",
+                {
+                    perf: {},
+                    searchString: "foo"
+                }
+            ),
+            /banana/
+        );
     }
 )
 
@@ -37,19 +47,83 @@ test(
     async t => {
         t.plan(1);
         const docSetId = "DBL/eng_engWEBBE";
-        const epitelete = new Epitelete({ proskomma, docSetId });
+        const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        t.throws(() => epitelete.makeDocumentReport("LUK", "banana", {}), /banana/);
+        t.throws(
+            () => epitelete.makeDocumentReport(
+                "LUK",
+                "banana",
+                {
+                    perf: {},
+                    searchString: "foo"
+                }
+            ),
+            /banana/
+        );
     }
 )
+
+test(
+    `makeDocumentReport() throws when inputs do not match spec (${testGroup})`,
+    async t => {
+        t.plan(3);
+        const docSetId = "DBL/eng_engWEBBE";
+        const epitelete = new Epitelete({proskomma, docSetId});
+        await epitelete.fetchPerf("LUK");
+        t.throws(
+            () => epitelete.makeDocumentReport(
+                "LUK",
+                "wordSearch",
+                {
+                    extra: "baa",
+                    perf: {},
+                    searchString: "foo"
+                }
+            ),
+            /3 provided/
+        );
+        t.throws(
+            () => epitelete.makeDocumentReport(
+                "LUK",
+                "wordSearch",
+                {
+                    perf: {},
+                    "baa": "foo"
+                }
+            ),
+            /searchString not provided/
+        );
+        t.throws(
+            () => epitelete.makeDocumentReport(
+                "LUK",
+                "wordSearch",
+                {
+                    perf: "perf",
+                    "searchString": "foo"
+                }
+            ),
+            /perf must be json/
+        );
+    }
+)
+
 
 test(
     `makeDocumentReport() does not throw with valid args (${testGroup})`,
     async t => {
         t.plan(1);
         const docSetId = "DBL/eng_engWEBBE";
-        const epitelete = new Epitelete({ proskomma, docSetId });
+        const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        t.doesNotThrow(() => epitelete.makeDocumentReport("LUK", "wordSearch", {}));
+        t.doesNotThrow(
+            () => epitelete.makeDocumentReport(
+                "LUK",
+                "wordSearch",
+                {
+                    perf: {},
+                    searchString: "foo"
+                }
+            )
+        );
     }
 )

--- a/test/code/makeDocumentReport.cjs
+++ b/test/code/makeDocumentReport.cjs
@@ -1,0 +1,55 @@
+const test = require("tape");
+const path = require("path");
+const fse = require("fs-extra");
+const {UWProskomma} = require("uw-proskomma");
+const Epitelete = require("../../src/index").default;
+
+const testGroup = "Reports";
+
+const proskomma = new UWProskomma();
+// const succinctJson = fse.readJsonSync(path.resolve(path.join(__dirname, "..", "test_data", "fra_lsg_succinct.json")));
+const succinctJson = fse.readJsonSync(path.resolve(path.join(__dirname, "..", "test_data", "eng_engWEBBE_succinct.json")));
+proskomma.loadSuccinctDocSet(succinctJson);
+
+test(
+    `makeDocumentReport() is defined (${testGroup})`,
+    async t => {
+        t.plan(1);
+        const docSetId = "DBL/eng_engWEBBE";
+        const epitelete = new Epitelete({ proskomma, docSetId });
+        t.ok(typeof epitelete.makeDocumentReport === "function");
+    }
+)
+
+test(
+    `makeDocumentReport() throws on bad bookCode (${testGroup})`,
+    async t => {
+        t.plan(1);
+        const docSetId = "DBL/eng_engWEBBE";
+        const epitelete = new Epitelete({ proskomma, docSetId });
+        await epitelete.fetchPerf("LUK");
+        t.throws(() => epitelete.makeDocumentReport("banana", "wordSearch", {}), /banana/);
+    }
+)
+
+test(
+    `makeDocumentReport() throws on bad reportName (${testGroup})`,
+    async t => {
+        t.plan(1);
+        const docSetId = "DBL/eng_engWEBBE";
+        const epitelete = new Epitelete({ proskomma, docSetId });
+        await epitelete.fetchPerf("LUK");
+        t.throws(() => epitelete.makeDocumentReport("LUK", "banana", {}), /banana/);
+    }
+)
+
+test(
+    `makeDocumentReport() does not throw with valid args (${testGroup})`,
+    async t => {
+        t.plan(1);
+        const docSetId = "DBL/eng_engWEBBE";
+        const epitelete = new Epitelete({ proskomma, docSetId });
+        await epitelete.fetchPerf("LUK");
+        t.doesNotThrow(() => epitelete.makeDocumentReport("LUK", "wordSearch", {}));
+    }
+)

--- a/test/code/makeDocumentReport.cjs
+++ b/test/code/makeDocumentReport.cjs
@@ -99,31 +99,31 @@ test(
                 "wordSearch",
                 {
                     perf: "perf",
-                    "searchString": "foo"
+                    "searchString": {}
                 }
             ),
-            /perf must be json/
+            /searchString must be text/
         );
     }
 )
 
 
 test(
-    `makeDocumentReport() does not throw with valid args (${testGroup})`,
+    `makeDocumentReport() returns output with valid args (${testGroup})`,
     async t => {
-        t.plan(1);
+        t.plan(2);
         const docSetId = "DBL/eng_engWEBBE";
         const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
-        t.doesNotThrow(
-            () => epitelete.makeDocumentReport(
-                "LUK",
-                "wordSearch",
-                {
-                    perf: {},
-                    searchString: "foo"
-                }
-            )
+        const output = epitelete.makeDocumentReport(
+            "LUK",
+            "wordSearch",
+            {
+                perf: {},
+                searchString: "Zacharias"
+            }
         );
+        t.ok('matches' in output);
+        t.ok(output.matches.includes("1:5"));
     }
 )

--- a/test/code/makeDocumentReport.cjs
+++ b/test/code/makeDocumentReport.cjs
@@ -88,7 +88,11 @@ test(
                 "wordSearch",
                 {
                     perf: {},
-                    "baa": "foo"
+                    "baa": "foo",
+                    "ignoreCase": "text",
+                    "asRegex": "text",
+                    "logic": "text",
+                    "asPartial": "text"
                 }
             ),
             /searchString not provided/
@@ -99,7 +103,11 @@ test(
                 "wordSearch",
                 {
                     perf: "perf",
-                    "searchString": {}
+                    "searchString": {},
+                    "ignoreCase": "text",
+                    "asRegex": "text",
+                    "logic": "text",
+                    "asPartial": "text"
                 }
             ),
             /searchString must be text/
@@ -111,7 +119,7 @@ test(
 test(
     `makeDocumentReport() returns output with valid args (${testGroup})`,
     async t => {
-        t.plan(2);
+        t.plan(4);
         const docSetId = "DBL/eng_engWEBBE";
         const epitelete = new Epitelete({proskomma, docSetId});
         await epitelete.fetchPerf("LUK");
@@ -120,10 +128,17 @@ test(
             "wordSearch",
             {
                 perf: {},
-                searchString: "Zacharias"
+                searchString: "Zacharias",
+                "ignoreCase": "1",
+                "asRegex": "0",
+                "logic": "A",
+                "asPartial": "0"
             }
         );
+        // console.log(output.matches.matches);
         t.ok('matches' in output);
-        t.ok(output.matches.includes("1:5"));
+        t.ok('searchTerms' in output.matches);
+        t.equal(output.matches.matches[0].chapter, '1');
+        t.equal(output.matches.matches[0].verses, '5');
     }
 )

--- a/test/code/makeDocumentReport.cjs
+++ b/test/code/makeDocumentReport.cjs
@@ -141,4 +141,34 @@ test(
         t.equal(output.matches.matches[0].chapter, '1');
         t.equal(output.matches.matches[0].verses, '5');
     }
+);
+
+test(
+    `makeDocumentsReport() (${testGroup})`,
+    async t => {
+        t.plan(5);
+        const docSetId = "DBL/eng_engWEBBE";
+        const epitelete = new Epitelete({proskomma, docSetId});
+        await epitelete.fetchPerf("MAT");
+        await epitelete.fetchPerf("MRK");
+        await epitelete.fetchPerf("LUK");
+        await epitelete.fetchPerf("JHN");
+        const output = epitelete.makeDocumentsReport(
+            "wordSearch",
+            {
+                perf: {},
+                searchString: "Zacharias",
+                "ignoreCase": "1",
+                "asRegex": "0",
+                "logic": "A",
+                "asPartial": "0"
+            }
+        );
+        // console.log(output.matches.matches);
+        t.ok('LUK' in output);
+        t.ok('matches' in output.LUK);
+        t.ok('searchTerms' in output.LUK.matches);
+        t.equal(output.LUK.matches.matches[0].chapter, '1');
+        t.equal(output.LUK.matches.matches[0].verses, '5');
+    }
 )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2899,10 +2899,10 @@ proskomma-json-tools@^0.4.0:
     ajv "^8.11.0"
     deep-equal "^2.0.5"
 
-proskomma-json-tools@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/proskomma-json-tools/-/proskomma-json-tools-0.4.1.tgz#0f7f48521506e6d440e109a432425b3c875d4235"
-  integrity sha512-GTpQe5bGrZ86Pl46oaR4H5fMnISyRseEiJ9fFKLG+hNLs2b5YJfr+XbicuCoAnsE5jcGrt9pxK4ue0S2nVYmAw==
+proskomma-json-tools@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/proskomma-json-tools/-/proskomma-json-tools-0.4.2.tgz#4f2f54144bfb45dba7b3092f56efc15a6f6b71c8"
+  integrity sha512-xaA8gq9EcCVUB8YMCGsWkWOjrP9dWW77cMXc0dH0M2TdfjgGXq6x++Kv5WH3PdXzj0T/gxn0TCf38sFRosC/wQ==
   dependencies:
     "@babel/core" "^7.17.10"
     "@babel/plugin-proposal-throw-expressions" "^7.18.6"


### PR DESCRIPTION
This PR takes a headless version of the wordSearch pipeline developed by @superdav42, @PhotoNomad0 and Joel and exposed it in Epitelete via a generic report-generating method.

`makeDocumentReport()` runs the pipeline against the book with the specified bookCode.
`makeDocumentsReport()` runs the pipeline against all locally-stored documents and returns the result as an object indexed by bookCode.

(A search on the 4 gospels takes 307msec on my system, which is in the same ballpark as Proskomma. At the UI end I'd recommend searching one book at a time and displaying results as they arrive.)

All tests pass, including the new ones. I didn't spend much time trying to work out exactly how the various flags work.